### PR TITLE
Fix safari date parsing

### DIFF
--- a/src/components/parseDate.js
+++ b/src/components/parseDate.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const parseDate = string => {
-    let fullDate = new Date(string);
+    let fullDate = new Date(string.replace(/-/g, "/"));
     let month = fullDate.toLocaleString('en', {month: "short"});
     let year = fullDate.getFullYear();
     let time = `${fullDate.getHours()}:${fullDate.getMinutes()}`;


### PR DESCRIPTION
Safari wants a date formatted via '/' instead of '-' (ex. `2020/12/14 18:30:00` instead of `2020-12-14 18:30:00` which is returned in response).

Fixed via regular expression that replaces dashes with slashes
